### PR TITLE
Enable input of DS100-Codes

### DIFF
--- a/scripts/acronyms.pl
+++ b/scripts/acronyms.pl
@@ -48,6 +48,12 @@ sub get_stations {
 sub get_station_by_name {
 	my ( $name ) = @_;
 
+	my $ds100_match = firstval { $nname eq $_->[0] } @stations;
+
+	if ($ds100_match) {
+		return ($ds100_match);
+	}
+
 	my $nname = lc($name);
 	my $actual_match = firstval { $nname eq lc($_->[1]) } @stations;
 


### PR DESCRIPTION
Some people like DS100-Codes, as they are shorter and for a small set of stations easier to keep in mind.
As they are in the database anyways, searching for them is just a matter of searchtime.
