### PR TITLE
Added github repo to dist metadata and the doc

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -32,5 +32,10 @@ Module::Build->new(
 		'XML::LibXML' => 0,
 	},
 	sign => 1,
+    meta_merge => {
+        resources => {
+            repository => 'https://github.com/derf/Travel-Status-DE-IRIS'
+        }
+    },
 
 )->create_build_script();

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Travel::Status::DE::IRIS 1.02 - ??? May ?? 2015
+
+    * Added github repo to dist metadata and the doc
+
 Travel::Status::DE::IRIS 1.01 - Fri May 15 2015
 
     * IRIS->new: Fix default lwp_options value (was documented, but not used)

--- a/lib/Travel/Status/DE/IRIS.pm
+++ b/lib/Travel/Status/DE/IRIS.pm
@@ -6,7 +6,7 @@ use 5.014;
 
 no if $] >= 5.018, warnings => 'experimental::smartmatch';
 
-our $VERSION = '1.01';
+our $VERSION = '1.02';
 
 use Carp qw(confess cluck);
 use DateTime;
@@ -501,6 +501,10 @@ Many backend features are not yet exposed.
 
 db-iris(1), Travel::Status::DE::IRIS::Result(3pm),
 Travel::Status::DE::IRIS::Stations(3pm)
+
+=head1 REPOSITORY
+
+L<https://github.com/derf/Travel-Status-DE-IRIS>
 
 =head1 AUTHOR
 


### PR DESCRIPTION
Hi,

This pull request adds the github repo to the dist's metadata. That means it will appear in the MetaCPAN sidebar, and various tools will be able to find it. For example this means your dist can be a candidate in the [CPAN Pull Request challenge](http://cpan-prc.orc).

I also added a link to the repo in the documentation.

Cheers,
Neil