### PR TITLE
Remove duplicate entry for Milano Centrale in stations.json

### DIFF
--- a/share/stations.json
+++ b/share/stations.json
@@ -43956,12 +43956,6 @@
       "name" : "Milano Centrale"
    },
    {
-      "ds100" : "XIMB",
-      "uic" : 8300046,
-      "latlong" : null,
-      "name" : "Milano Centrale"
-   },
-   {
       "ds100" : "XIMG",
       "uic" : 8300416,
       "latlong" : null,


### PR DESCRIPTION
(Probably) Fixes https://github.com/derf/Travel-Status-DE-IRIS/pull/12#issuecomment-554754353