### PR TITLE
Add Merklingen station on SFS Wendlingen - Ulm

### DIFF
--- a/share/stations.json
+++ b/share/stations.json
@@ -49518,6 +49518,15 @@
       "name" : "Mering-St Afra"
    },
    {
+      "ds100" : "TMKL",
+      "eva" : 8003983,
+      "latlong" : [
+         48.5211319,
+         9.7410035
+      ],
+      "name" : "Merklingen - Schwäbische Alb"
+   },
+   {
       "ds100" : "XLM",
       "eva" : 8200110,
       "latlong" : [


### PR DESCRIPTION
This adds "Merklingen - Schwäbische Alb" station on the new high speed line Wendlingen-Ulm, which was opened today. 

However, the pull request is probably not ready for integration yet, because the IRIS API does not know the station (DS100 code) as of now. For the EVA number, it returns a DS100 code of "D8003983".